### PR TITLE
Fix running in docker: This version of ChromeDriver only supports Chr…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ultrafunk/undetected-chromedriver:106
+FROM ultrafunk/undetected-chromedriver:3.20-chrome-lateinstall
 
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
…ome version 117

full error text:

selenium.common.exceptions.SessionNotCreatedException: Message: session not created: This version of ChromeDriver only supports Chrome version 117 Current browser version is 106.0.5249.119 with binary path /opt/google/chrome/chrome